### PR TITLE
arm64 Linux & macOS buiild fixes, MP framework bugfix

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
+
 # Copyright 2022 The MediaPipe Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 licenses(["notice"])
 
@@ -46,8 +47,12 @@ pkg_files(
         "//mediapipe/calculators/core:mediapipe_calculators_core",
         "//mediapipe/framework:mediapipe_framework",
         "//mediapipe/framework/formats:mediapipe_framework_formats",
-        "//mediapipe/gpu:mediapipe_gpu",
-    ],
+    ] + select({
+        "//conditions:default": [
+            "//mediapipe/gpu:mediapipe_gpu",
+        ],
+        "//mediapipe/gpu:disable_gpu": [],
+    }),
     prefix = "lib",
     visibility = ["//visibility:public"],
 )

--- a/mediapipe/framework/subgraph.h
+++ b/mediapipe/framework/subgraph.h
@@ -41,7 +41,7 @@ class SubgraphContext {
   // @node and/or @service_manager can be nullptr.
   SubgraphContext(CalculatorGraphConfig::Node* node,
                   std::shared_ptr<GraphServiceManager> service_manager)
-      : default_node_(node ? absl::nullopt
+      : default_node_(node ? std::nullopt
                            : std::optional<CalculatorGraphConfig::Node>(
                                  CalculatorGraphConfig::Node())),
         original_node_(node ? *node : default_node_.value()),

--- a/third_party/opencv_linux.BUILD
+++ b/third_party/opencv_linux.BUILD
@@ -15,20 +15,21 @@ cc_library(
     name = "opencv",
     hdrs = glob([
         # For OpenCV 4.x
-        #"include/aarch64-linux-gnu/opencv4/opencv2/cvconfig.h",
+        "include/aarch64-linux-gnu/opencv4/opencv2/cvconfig.h",
         #"include/arm-linux-gnueabihf/opencv4/opencv2/cvconfig.h",
         #"include/x86_64-linux-gnu/opencv4/opencv2/cvconfig.h",
         "include/opencv4/opencv2/**/*.h*",
     ]),
     includes = [
         # For OpenCV 4.x
-        #"include/aarch64-linux-gnu/opencv4/",
+        "include/aarch64-linux-gnu/opencv4/",
         #"include/arm-linux-gnueabihf/opencv4/",
         #"include/x86_64-linux-gnu/opencv4/",
         "include/opencv4/",
     ],
     linkopts = [
         "-L/usr/local/lib",
+        "-L/usr/lib/aarch64-linux-gnu",
         "-l:libopencv_core.so",
         "-l:libopencv_calib3d.so",
         "-l:libopencv_features2d.so",


### PR DESCRIPTION
- Fix MP framework bug that manifests itself with newer Clang compilers on macOS (already fixed in upstream MP)
- Fix GPU code exclusions such that GPU code isn't built into the package for CMake when `--define MEDIAPIPE_DISABLE_GPU=1` is passed to Bazel (e.g. on macOS)
- Add OpenCV header config for arm64 Linux