### PR TITLE
feat(FaceDetection): switchable full/short in CPU graph

### DIFF
--- a/mediapipe/modules/face_detection/face_detection_full_range.pbtxt
+++ b/mediapipe/modules/face_detection/face_detection_full_range.pbtxt
@@ -16,6 +16,9 @@ type: "FaceDetectionFullRange"
 # The input image, either ImageFrame, GpuBuffer, or (multi-backend) Image.
 input_stream: "IMAGE:image"
 
+# Path to the face detection model. (string)
+input_side_packet: "MODEL_PATH:model_path"
+
 # ROI (region of interest) within the given image where faces should be
 # detected. (NormalizedRect)
 input_stream: "ROI:roi"
@@ -32,9 +35,9 @@ node {
   input_stream: "IMAGE:image"
   input_stream: "ROI:roi"
   output_stream: "DETECTIONS:detections"
+  input_side_packet: "MODEL_PATH:model_path"
   node_options: {
     [type.googleapis.com/mediapipe.FaceDetectionOptions] {
-      model_path: "mediapipe/modules/face_detection/face_detection_full_range_sparse.tflite"
       tensor_width: 192
       tensor_height: 192
 

--- a/mediapipe/modules/face_detection/face_detection_full_range_cpu.pbtxt
+++ b/mediapipe/modules/face_detection/face_detection_full_range_cpu.pbtxt
@@ -5,6 +5,9 @@ type: "FaceDetectionFullRangeCpu"
 # The input image, either ImageFrame, or (multi-backend) Image.
 input_stream: "IMAGE:image"
 
+# Path to the face detection model. (string)
+input_side_packet: "MODEL_PATH:model_path"
+
 # Detected faces. (std::vector<Detection>)
 output_stream: "DETECTIONS:detections"
 
@@ -15,6 +18,7 @@ graph_options: {
 node {
   calculator: "FaceDetectionFullRange"
   input_stream: "IMAGE:image"
+  input_side_packet: "MODEL_PATH:model_path"
   output_stream: "DETECTIONS:detections"
   node_options: {
     [type.googleapis.com/mediapipe.FaceDetectionOptions] {

--- a/mediapipe/modules/face_landmark/BUILD
+++ b/mediapipe/modules/face_landmark/BUILD
@@ -84,6 +84,8 @@ mediapipe_simple_subgraph(
         "//mediapipe/calculators/image:image_properties_calculator",
         "//mediapipe/calculators/util:association_norm_rect_calculator",
         "//mediapipe/calculators/util:collection_has_min_size_calculator",
+        "//mediapipe/framework/tool:switch_container",
+        "//mediapipe/modules/face_detection:face_detection_full_range_cpu",
         "//mediapipe/modules/face_detection:face_detection_short_range_cpu",
     ],
 )

--- a/mediapipe/modules/face_landmark/face_landmark_front_cpu.pbtxt
+++ b/mediapipe/modules/face_landmark/face_landmark_front_cpu.pbtxt
@@ -34,8 +34,12 @@ input_side_packet: "NUM_FACES:num_faces"
 
 # Path to the face detection model. (string)
 input_side_packet: "FACE_DETECTION_MODEL_PATH:face_detection_model_path"
+# Whether to use short- or full-range face detection calculator configuration,
+# regardless of tflite model file path. (bool)
+input_side_packet: "USE_FULL_RANGE_FACE_DETECTION:use_full_range_face_detection"
 # Path to the face landmark model. (string)
 input_side_packet: "FACE_LANDMARK_MODEL_PATH:face_landmark_model_path"
+
 
 # Whether landmarks on the previous image should be used to help localize
 # landmarks on the current image. (bool)
@@ -98,12 +102,22 @@ node {
   }
 }
 
-# Detects faces.
 node {
-  calculator: "FaceDetectionShortRangeCpu"
-  input_stream: "IMAGE:gated_image"
+  calculator: "SwitchContainer"
+  input_side_packet: "ENABLE:use_full_range_face_detection"
   input_side_packet: "MODEL_PATH:face_detection_model_path"
+  input_stream: "IMAGE:gated_image"
   output_stream: "DETECTIONS:all_face_detections"
+  options {
+    [mediapipe.SwitchContainerOptions.ext] {
+      contained_node: {
+        calculator: "FaceDetectionShortRangeCpu"
+      }
+      contained_node: {
+        calculator: "FaceDetectionFullRangeCpu"
+      }
+    }
+  }
 }
 
 # Makes sure there are no more detections than the provided num_faces.


### PR DESCRIPTION
- Get the `face_landmark_front_cpu.pbtxt` graph to accept a `use_full_range_face_detection` side-packet.
- Make the side packet control how the face detection calculator is configured -- using a SwitchContaner calculator to switch between the configurations, since the configurations have their own subgraphs.
- Also, allow model path to be switched for the full-range face detection on CPU, allowing us to feed in the correct model when the `use_full_range_face_detection` is set to true.