### PR TITLE
Fix CachedFileFromAsset race condition causing sporadic TfLite model load failures

### DIFF
--- a/mediapipe/util/android/asset_manager_util.cc
+++ b/mediapipe/util/android/asset_manager_util.cc
@@ -14,7 +14,9 @@
 
 #include "mediapipe/util/android/asset_manager_util.h"
 
+#include <cstdio>
 #include <fstream>
+#include <unistd.h>
 
 #include "absl/log/absl_check.h"
 #include "absl/log/absl_log.h"
@@ -171,11 +173,29 @@ absl::StatusOr<std::string> AssetManager::CachedFileFromAsset(
   std::string dir_path = File::StripBasename(file_path);
   MP_RETURN_IF_ERROR(file::RecursivelyCreateDir(dir_path, file::Defaults()));
 
-  std::ofstream output_file(file_path);
-  RET_CHECK(output_file.good()) << "could not open cache file: " << file_path;
+  // Write to a thread-specific temporary file first, then atomically rename to
+  // the final path. This prevents a race where concurrent calculator threads
+  // loading the same model truncate each other's in-progress writes via
+  // std::ofstream (which uses O_TRUNC). POSIX rename() is atomic when src and
+  // dst are on the same filesystem (both are under cache_dir here).
+  std::string tmp_path =
+      absl::StrCat(file_path, ".tmp.", getpid(), ".", gettid());
 
-  output_file << asset_data;
-  RET_CHECK(output_file.good()) << "could not write cache file: " << file_path;
+  {
+    std::ofstream output_file(tmp_path);
+    RET_CHECK(output_file.good())
+        << "could not open temp cache file: " << tmp_path;
+
+    output_file << asset_data;
+    RET_CHECK(output_file.good())
+        << "could not write temp cache file: " << tmp_path;
+  }
+
+  if (std::rename(tmp_path.c_str(), file_path.c_str()) != 0) {
+    std::remove(tmp_path.c_str());
+    return absl::InternalError(
+        absl::StrCat("could not rename temp cache file to: ", file_path));
+  }
 
   return file_path;
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `CachedFileFromAsset` uses `std::ofstream` to write model cache files, which truncates on open (`O_TRUNC`). When multiple calculator threads load the same model concurrently, one thread's truncation destroys the other's in-progress write. `GetResourceContents` then reads an empty/partial file → `"Failed to read file"`.
- **Fix**: Write to a per-thread temp file (`<path>.tmp.<pid>.<tid>`), then atomically `rename()` to the final path. POSIX `rename()` is atomic on the same filesystem, so concurrent writers always produce a valid file.
- This is Android-only code (`mediapipe/util/android/`); the BUILD file gates compilation to `//mediapipe:android`.

## Context

Observed in the Presage SmartSpectra Android SDK: rapid checkup→back→checkup cycles sporadically fail with `LocalFileContentsCalculator::Open() failed: Failed to read file`. The race is between two calculator instances that both load `face_detection_short_range.tflite` on different threads during `CalculatorGraph::preheat()`.

MediaPipe's own documentation in `asset_manager_util.h:96-98` notes that `CachedFileFromAsset` is _not_ thread-safe.

## Test plan

- [x] Reproduced the sporadic failure on a Pixel 7 (Android 16) — fails within ~5 rapid restarts
- [x] Applied the fix, ran 50+ consecutive checkup cycles across 2 app launches with zero failures
- [x] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)