### PR TITLE
build(opencv): move optflow contrib dependency out of opencv_video_inc.h into the guarded TVL1 calculator

### DIFF
--- a/mediapipe/calculators/video/tvl1_optical_flow_calculator.cc
+++ b/mediapipe/calculators/video/tvl1_optical_flow_calculator.cc
@@ -21,6 +21,13 @@
 #include "mediapipe/framework/formats/motion/optical_flow_field.h"
 #include "mediapipe/framework/port/opencv_video_inc.h"
 
+// Dense TVL1 optical flow is provided by the opencv_contrib `optflow` module
+// (cv::optflow::createOptFlow_DualTVL1). Builds against a trimmed/contrib-less
+// OpenCV define MEDIAPIPE_DISABLE_OPENCV_CONTRIB, which compiles this calculator
+// out entirely so the build succeeds without the optflow module.
+#if !defined(MEDIAPIPE_DISABLE_OPENCV_CONTRIB)
+#include <opencv2/optflow.hpp>
+
 namespace mediapipe {
 namespace {
 
@@ -120,7 +127,7 @@ absl::Status Tvl1OpticalFlowCalculator::GetContract(CalculatorContract* cc) {
 absl::Status Tvl1OpticalFlowCalculator::Open(CalculatorContext* cc) {
   {
     absl::MutexLock lock(mutex_);
-    tvl1_computers_.emplace_back(cv::createOptFlow_DualTVL1());
+    tvl1_computers_.emplace_back(cv::optflow::createOptFlow_DualTVL1());
   }
   if (cc->Outputs().HasTag(kForwardFlowTag)) {
     forward_requested_ = true;
@@ -177,7 +184,7 @@ absl::Status Tvl1OpticalFlowCalculator::CalculateOpticalFlow(
     }
   }
   if (tvl1_computer.empty()) {
-    tvl1_computer = cv::createOptFlow_DualTVL1();
+    tvl1_computer = cv::optflow::createOptFlow_DualTVL1();
   }
 
   flow->Allocate(first.cols, first.rows);
@@ -195,3 +202,5 @@ absl::Status Tvl1OpticalFlowCalculator::CalculateOpticalFlow(
 REGISTER_CALCULATOR(Tvl1OpticalFlowCalculator);
 
 }  // namespace mediapipe
+
+#endif  // !defined(MEDIAPIPE_DISABLE_OPENCV_CONTRIB)

--- a/mediapipe/framework/port/opencv_video_inc.h
+++ b/mediapipe/framework/port/opencv_video_inc.h
@@ -84,16 +84,6 @@ inline int fourcc(char c1, char c2, char c3, char c4) {
 #include <opencv2/video.hpp>
 #include <opencv2/videoio.hpp>
 
-#if CV_VERSION_MAJOR == 4 && !defined(MEDIAPIPE_MOBILE)
-#include <opencv2/optflow.hpp>
-
-namespace cv {
-inline Ptr<DenseOpticalFlow> createOptFlow_DualTVL1() {
-  return optflow::createOptFlow_DualTVL1();
-}
-}  // namespace cv
-#endif
-
 namespace mediapipe {
 inline int fourcc(char c1, char c2, char c3, char c4) {
   return cv::VideoWriter::fourcc(c1, c2, c3, c4);


### PR DESCRIPTION
## Summary

`mediapipe/framework/port/opencv_video_inc.h` defined an inline
`cv::createOptFlow_DualTVL1()` shim guarded only by
`CV_VERSION_MAJOR == 4 && !defined(MEDIAPIPE_MOBILE)`, pulling
`<opencv2/optflow.hpp>` — and therefore **opencv_contrib** — into *every*
non-mobile consumer of this widely-included port header. A trimmed/static
OpenCV that omits contrib (e.g. a hidden-visibility static tarball) cannot
compile against the header.

This PR **relocates** the optflow dependency out of the shared port header and
into its sole consumer, `Tvl1OpticalFlowCalculator`:

- `opencv_video_inc.h`: the `<opencv2/optflow.hpp>` include and the
  `createOptFlow_DualTVL1()` shim are removed.
- `tvl1_optical_flow_calculator.cc`: now includes `<opencv2/optflow.hpp>`
  directly and calls `cv::optflow::createOptFlow_DualTVL1()` at its two
  callsites (previously it relied on the now-removed shim — it did **not**
  include optflow directly).
- The calculator's optflow include + body + `REGISTER_CALCULATOR` are wrapped
  in `#if !defined(MEDIAPIPE_DISABLE_OPENCV_CONTRIB)`. Default-undefined, so
  behavior is unchanged when contrib is present; a contrib-less build defines
  the macro and the translation unit compiles out cleanly.

Net effect: `opencv_video_inc.h` no longer forces opencv_contrib on its many
consumers, while the optflow capability stays available to the TVL1 calculator
against a contrib OpenCV.

> **Base:** retargeted to `presage_v0.10.35_slim` — the branch the Presage
> Physiology Edge build pins. (Supersedes the earlier shim-only revision that
> targeted `presage_v0.10.15`.)

## Behavior

No change for any consumer built today: when contrib is present the TVL1
calculator compiles and registers exactly as before. The change is inert for
the Physiology Edge build, which does not compile the TVL1 calculator at all.

## Test plan

- [x] `opencv_video_inc.h` consumers build with the shim removed:
      `bazel build //mediapipe/calculators/video:{opencv_video_decoder_calculator,opencv_video_encoder_calculator}`
      compiles with zero errors (they no longer pull contrib through the header).
- [x] Contrib-less guard verified: `bazel build
      //mediapipe/calculators/video:tvl1_optical_flow_calculator
      --copt=-DMEDIAPIPE_DISABLE_OPENCV_CONTRIB` → `Build completed successfully`
      (guarded-out TU → empty object).
- [x] The relocated `<opencv2/optflow.hpp>` include + `cv::optflow::createOptFlow_DualTVL1()`
      callsites compile with no optflow-related errors.

## Known / out of scope

Building the full TVL1 target *with* contrib on `presage_v0.10.35_slim` fails on
a **pre-existing**, optflow-unrelated `absl::MutexLock` API mismatch
(`absl::MutexLock lock(mutex_)` where current `@com_google_absl` requires
`lock(&mutex_)`, at 3 sites). This is present on the pristine slim tip and is
left untouched here — the target is built by neither the Edge consumer nor this
fork's CI. (The `presage_v0.10.15` line already had the correct `&mutex_` form.)

---

Paired with the internal Presage Physiology MR that bumps the `edge/WORKSPACE`
MediaPipe pin to this PR's merge commit (OpenCV-Linux MR-0).
