### PR TITLE
fix(gpu): enable Metal GPU inference on macOS (CVPixelBuffer + 4.1 core GL)

### DIFF
--- a/mediapipe/calculators/image/affine_transformation_runner_gl.cc
+++ b/mediapipe/calculators/image/affine_transformation_runner_gl.cc
@@ -277,29 +277,35 @@ class GlTextureWarpAffineRunner
     glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
     glViewport(0, 0, output->width(), output->height());
 
+    // Bind textures with their actual GL target: GL_TEXTURE_2D on iOS/Android,
+    // but GL_TEXTURE_RECTANGLE on macOS (CVPixelBuffer GpuBuffers go through
+    // CVOpenGLTextureCache -> RECTANGLE). Hardcoding GL_TEXTURE_2D bound/parameterized
+    // the wrong target on macOS -> per-frame GL_INVALID_OPERATION.
+    const GLenum out_target = output->target();
+    const GLenum in_target = texture.target();
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, output->name());
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+    glBindTexture(out_target, output->name());
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, out_target,
                            output->name(), 0);
 
     glActiveTexture(GL_TEXTURE1);
-    glBindTexture(texture.target(), texture.name());
+    glBindTexture(in_target, texture.name());
 
     // a) Filtering.
     if (interpolation_ == AffineTransformation::Interpolation::kNearest) {
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+      glTexParameteri(in_target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+      glTexParameteri(in_target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     } else {
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      glTexParameteri(in_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameteri(in_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     }
 
     // b) Clamping.
     std::optional<Program> program = program_;
     switch (border_mode) {
       case AffineTransformation::BorderMode::kReplicate: {
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameteri(in_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(in_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
         break;
       }
       case AffineTransformation::BorderMode::kZero: {
@@ -307,9 +313,9 @@ class GlTextureWarpAffineRunner
         if (program_custom_zero_) {
           program = program_custom_zero_;
         } else {
-          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-          glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR,
+          glTexParameteri(in_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+          glTexParameteri(in_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+          glTexParameterfv(in_target, GL_TEXTURE_BORDER_COLOR,
                            std::array<float, 4>{0.0f, 0.0f, 0.0f, 0.0f}.data());
         }
 #else
@@ -365,10 +371,10 @@ class GlTextureWarpAffineRunner
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
     // Resetting to MediaPipe texture param defaults.
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(in_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(in_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(in_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(in_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     glDisableVertexAttribArray(kAttribVertex);
     glDisableVertexAttribArray(kAttribTexturePosition);
@@ -376,9 +382,9 @@ class GlTextureWarpAffineRunner
     glBindVertexArray(0);
 
     glActiveTexture(GL_TEXTURE1);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    glBindTexture(in_target, 0);
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    glBindTexture(out_target, 0);
 
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 

--- a/mediapipe/calculators/tensor/tensors_to_segmentation_converter_metal.cc
+++ b/mediapipe/calculators/tensor/tensors_to_segmentation_converter_metal.cc
@@ -290,10 +290,14 @@ TensorsToSegmentationMetalConverter::Convert(const Tensor& input_tensor,
     {
       gpu_helper_.BindFramebuffer(output_texture);
       glActiveTexture(GL_TEXTURE1);
-      glBindTexture(GL_TEXTURE_2D, small_mask_texture.name());
+      // Bind with the texture's actual target: GL_TEXTURE_2D on iOS/Android, but
+      // GL_TEXTURE_RECTANGLE on macOS (CVPixelBuffer GpuBuffers are RECTANGLE via
+      // CVOpenGLTextureCache). Hardcoding GL_TEXTURE_2D bound a RECTANGLE texture
+      // to the wrong target → per-frame GL_INVALID_OPERATION on macOS.
+      glBindTexture(small_mask_texture.target(), small_mask_texture.name());
       glUseProgram(upsample_program_);
       GlRender();
-      glBindTexture(GL_TEXTURE_2D, 0);
+      glBindTexture(small_mask_texture.target(), 0);
       glFlush();
     }
 

--- a/mediapipe/gpu/gl_context_nsgl.cc
+++ b/mediapipe/gpu/gl_context_nsgl.cc
@@ -52,9 +52,14 @@ absl::Status GlContext::CreateContext(NSOpenGLContext* share_context) {
   // hardware).
   // TODO: Remove the need for the OSX_ENABLE_3_2_CORE if this
   // proves to be safe in general.
-#if defined(TARGET_OS_OSX) && defined(OSX_ENABLE_3_2_CORE)
+#if defined(TARGET_OS_OSX)
+      // Presage fork: request a 4.1 core profile on macOS so MediaPipe's GLSL
+      // "#version 330" shaders compile. The default (no profile) is a legacy
+      // 2.1 context (GLSL 120 only), and even upstream's gated 3.2-core path
+      // (GLSL 150) is still < 330. Apple Silicon supports GL 4.1 core. This only
+      // affects GPU-enabled macOS builds. Upstream TODO: make this the default.
       NSOpenGLPFAOpenGLProfile,
-      NSOpenGLProfileVersion3_2Core,
+      NSOpenGLProfileVersion4_1Core,
 #endif
       NSOpenGLPFAAccelerated,
       NSOpenGLPFAColorSize,

--- a/mediapipe/gpu/gpu_buffer_format.h
+++ b/mediapipe/gpu/gpu_buffer_format.h
@@ -19,9 +19,12 @@
 
 #ifdef __APPLE__
 #include <CoreVideo/CoreVideo.h>
-#if !TARGET_OS_OSX
+// Presage fork: enable CVPixelBuffer-backed GpuBuffers on macOS too, not just
+// iOS. CoreVideo and CVMetalTextureCache are available on macOS, so this lets
+// MPPMetalHelper's metalTextureWithGpuBuffer: and the Metal image-to-tensor
+// converter compile/link there, unblocking the TFLite Metal inference delegate
+// on macOS (GPU inference offload). Upstream gates this to iOS only.
 #define MEDIAPIPE_GPU_BUFFER_USE_CV_PIXEL_BUFFER 1
-#endif  // TARGET_OS_OSX
 #endif  // defined(__APPLE__)
 
 #include "mediapipe/framework/formats/image_format.pb.h"


### PR DESCRIPTION
Enables the TFLite **Metal** inference delegate (and the full GPU graph) to compile/run on **macOS**, which previously only worked on iOS. Two independent macOS gaps:

1. **`gpu/gpu_buffer_format.h`** — `MEDIAPIPE_GPU_BUFFER_USE_CV_PIXEL_BUFFER` was gated to iOS (`!TARGET_OS_OSX`), so `MPPMetalHelper metalTextureWithGpuBuffer:` and the Metal image-to-tensor / segmentation converters didn't compile on macOS. CoreVideo + `CVMetalTextureCache` are available on macOS, so enable it there too.

2. **`gpu/gl_context_nsgl.cc`** — the NSGL context defaulted to legacy **2.1** (GLSL 120) unless `OSX_ENABLE_3_2_CORE` was defined, and even that path used 3.2 (GLSL 150) — both `< 330`. MediaPipe's GL shaders are `#version 330`, so they failed to compile (e.g. the segmentation upsample program via `GlhCreateProgram`). Request `NSOpenGLProfileVersion4_1Core` on macOS (Apple Silicon supports GL 4.1 core).

**Scope:** GPU-enabled macOS builds only — no effect on iOS/Android/Linux or on macOS builds with `MEDIAPIPE_DISABLE_GPU=1`.

**Validated** downstream (Presage edge graph on M4 Max): full face+pose+segmentation graph runs on Metal end-to-end; `face_landmark_with_attention` delegates 712/712 in a single partition; pulse/breathing outputs match the XNNPACK/CPU path.